### PR TITLE
Cleanup created files in case of failure on copy

### DIFF
--- a/src/efs.c
+++ b/src/efs.c
@@ -126,6 +126,8 @@ static int encrypt_storage(char *storage_path, char *passwd)
         /* Try to fail gracefully */
         remove_dir_content(private_dir_path);
         umount_ecryptfs(private_dir_path);
+        remove(private_dir_path);
+        remove(key_storage_path);
         return ret;
     }
 


### PR DESCRIPTION
Storage path and created key are now removed in case the file copy operation fails.
