### PR TITLE
Integrate multi-user encryption

### DIFF
--- a/integration/apply_patches.sh
+++ b/integration/apply_patches.sh
@@ -27,6 +27,7 @@ case $version in
         git apply "$basepath/$version/sepolicy/sepolicy.patch" --directory=external/sepolicy
         cp "$basepath/$version/sepolicy/efs.te" external/sepolicy/
         git apply "$basepath/$version/build/build.patch" --directory=build/
+        git apply "$basepath/$version/settings/settings.patch" --directory=packages/apps/Settings/
         ;;
     "android-4.4.4_r2")
         cp "$basepath/$version/vold/EncryptedFileStorageCmd.cpp" system/vold/

--- a/integration/user/android-5.0.2_r1/frameworks-base/frameworks-base.patch
+++ b/integration/user/android-5.0.2_r1/frameworks-base/frameworks-base.patch
@@ -1,42 +1,371 @@
-From 5b61b96baecc087df68e9c1f9b7eebdd4cce93f7 Mon Sep 17 00:00:00 2001
+From 7e04940fd369e85bb1c110f3eeb8a69b72d35445 Mon Sep 17 00:00:00 2001
 From: Nicolae-Alexandru Ivan <alexandru.ivan@intel.com>
-Date: Mon, 23 Mar 2015 17:10:56 +0200
-Subject: [PATCH] Add EFSService
+Date: Wed, 29 Apr 2015 15:47:50 +0300
+Subject: [PATCH] Integrate multi-user encryption into framework
 
+Known issue: When locking/unlocking the user there may be processes that
+have open file descriptors inside the storage. Currently, we just kill
+these and it sometimes results in error dialogs that are not cleared and
+get to the user. Functionally, the process has already been restarted by
+the time the user sees the message.
 ---
- api/current.txt                                    | 18 ++++++++++++++++++
- services/java/com/android/server/SystemServer.java |  9 +++++++++
- 2 files changed, 27 insertions(+)
+ core/java/android/content/pm/UserInfo.java         |  8 +++
+ .../android/keyguard/KeyguardAbsKeyInputView.java  | 24 ++++++++
+ packages/SystemUI/res/values/strings.xml           |  5 ++
+ .../statusbar/policy/UserSwitcherController.java   | 71 ++++++++++++++++++----
+ .../com/android/server/pm/UserManagerService.java  | 32 +++++++++-
+ .../java/com/android/server/power/Notifier.java    | 16 +++++
+ services/java/com/android/server/SystemServer.java |  9 +++
+ 7 files changed, 151 insertions(+), 14 deletions(-)
 
-diff --git a/api/current.txt b/api/current.txt
-index fe0c209..6bf244b 100644
---- a/api/current.txt
-+++ b/api/current.txt
-@@ -22368,6 +22368,24 @@ package android.os {
+diff --git a/core/java/android/content/pm/UserInfo.java b/core/java/android/content/pm/UserInfo.java
+index c03be32..4bcd40a 100644
+--- a/core/java/android/content/pm/UserInfo.java
++++ b/core/java/android/content/pm/UserInfo.java
+@@ -75,6 +75,10 @@ public class UserInfo implements Parcelable {
+      */
+     public static final int FLAG_DISABLED = 0x00000040;
  
- package android.os.storage {
++    /**
++     * Encrypted
++     */
++    public static final int FLAG_ENCRYPTED = 0x00000080;
  
-+  public abstract interface IEFSService implements android.os.IInterface {
-+    method public abstract int changePasswordEfsStorage(java.lang.String, java.lang.String, java.lang.String) throws android.os.RemoteException;
-+    method public abstract int createEfsStorage(java.lang.String, java.lang.String) throws android.os.RemoteException;
-+    method public abstract int getEfsEncryptionProgress(java.lang.String) throws android.os.RemoteException;
-+    method public abstract int getEfsStorageStat(java.lang.String) throws android.os.RemoteException;
-+    method public abstract int lockEfsStorage(java.lang.String) throws android.os.RemoteException;
-+    method public abstract int recoverDataAndRemoveEfsStorage(java.lang.String, java.lang.String) throws android.os.RemoteException;
-+    method public abstract int removeEfsStorage(java.lang.String) throws android.os.RemoteException;
-+    method public abstract int unlockEfsStorage(java.lang.String, java.lang.String) throws android.os.RemoteException;
-+  }
+     public static final int NO_PROFILE_GROUP_ID = -1;
+ 
+@@ -127,6 +131,10 @@ public class UserInfo implements Parcelable {
+         return (flags & FLAG_DISABLED) != FLAG_DISABLED;
+     }
+ 
++    public boolean isEncrypted() {
++        return (flags & FLAG_ENCRYPTED) == FLAG_ENCRYPTED;
++    }
 +
-+  public static abstract class IEFSService.Stub extends android.os.Binder implements android.os.storage.IEFSService {
-+    ctor public IEFSService.Stub();
-+    method public android.os.IBinder asBinder();
-+    method public static android.os.storage.IEFSService asInterface(android.os.IBinder);
-+    method public boolean onTransact(int, android.os.Parcel, android.os.Parcel, int) throws android.os.RemoteException;
-+  }
+     /**
+      * @return true if this user can be switched to.
+      **/
+diff --git a/packages/Keyguard/src/com/android/keyguard/KeyguardAbsKeyInputView.java b/packages/Keyguard/src/com/android/keyguard/KeyguardAbsKeyInputView.java
+index a411df3..e1a299a 100644
+--- a/packages/Keyguard/src/com/android/keyguard/KeyguardAbsKeyInputView.java
++++ b/packages/Keyguard/src/com/android/keyguard/KeyguardAbsKeyInputView.java
+@@ -19,13 +19,20 @@ package com.android.keyguard;
+ import android.content.Context;
+ import android.graphics.drawable.Drawable;
+ import android.os.CountDownTimer;
++import android.os.IBinder;
++import android.os.ServiceManager;
+ import android.os.SystemClock;
++import android.os.storage.IEFSService;
+ import android.util.AttributeSet;
++import android.util.Log;
+ import android.view.HapticFeedbackConstants;
+ import android.view.KeyEvent;
+ import android.view.View;
+ import android.widget.LinearLayout;
+ 
++import android.app.ActivityManagerNative;
++import android.app.IActivityManager;
 +
-   public abstract class OnObbStateChangeListener {
-     ctor public OnObbStateChangeListener();
-     method public void onObbStateChange(java.lang.String, int);
+ import com.android.internal.widget.LockPatternUtils;
+ 
+ /**
+@@ -103,8 +110,25 @@ public abstract class KeyguardAbsKeyInputView extends LinearLayout
+ 
+     protected void verifyPasswordAndUnlock() {
+         String entry = getPasswordText();
++        int currentUser = mLockPatternUtils.getCurrentUser();
+         if (mLockPatternUtils.checkPassword(entry)) {
+             mCallback.reportUnlockAttempt(true);
++            final IBinder efsbinder = ServiceManager.getService("efsservice");
++            final IBinder ambinder = ServiceManager.getService("activity");
++            if (efsbinder != null && ambinder != null) {
++                final IEFSService service = IEFSService.Stub.asInterface(efsbinder);
++                final IActivityManager am = ActivityManagerNative.asInterface(ambinder);
++                if (service != null && am != null) {
++                    try {
++                        am.startUserInBackground(0);
++                        am.stopUser(currentUser, null);
++                        service.unlockUserData(0, currentUser, entry);
++                        am.startUserInBackground(currentUser);
++                    } catch (Exception e) {
++                        Log.e("EFS", "Error unlocking secure storage", e);
++                    }
++                }
++            }
+             mCallback.dismiss(true);
+         } else {
+             if (entry.length() > MINIMUM_PASSWORD_LENGTH_BEFORE_REPORT ) {
+diff --git a/packages/SystemUI/res/values/strings.xml b/packages/SystemUI/res/values/strings.xml
+index 71b9b61..2ebf887 100644
+--- a/packages/SystemUI/res/values/strings.xml
++++ b/packages/SystemUI/res/values/strings.xml
+@@ -803,6 +803,11 @@
+     <!-- Message for add user confirmation dialog - short version. [CHAR LIMIT=none] -->
+     <string name="user_add_user_message_short" msgid="1511354412249044381">When you add a new user, that person needs to set up their space.\n\nAny user can update apps for all other users. </string>
+ 
++    <!-- Title for user encryption dialog [CHAR LIMIT=30] -->
++    <string name="user_encrypt_title">Encryption</string>
++
++    <!-- Message for user encryption dialog [CHAR LIMIT=none] -->
++    <string name="user_encrypt_message">Encrpyt new user?</string>
+ 
+     <!-- Battery saver notification title. [CHAR LIMIT=60]-->
+     <string name="battery_saver_notification_title">Battery saver is on</string>
+diff --git a/packages/SystemUI/src/com/android/systemui/statusbar/policy/UserSwitcherController.java b/packages/SystemUI/src/com/android/systemui/statusbar/policy/UserSwitcherController.java
+index 5c7909a..4d12d89 100644
+--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/UserSwitcherController.java
++++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/UserSwitcherController.java
+@@ -28,6 +28,9 @@ import android.content.pm.UserInfo;
+ import android.database.ContentObserver;
+ import android.graphics.Bitmap;
+ import android.graphics.drawable.Drawable;
++import android.os.IBinder;
++import android.os.storage.IEFSService;
++import android.os.ServiceManager;
+ import android.os.AsyncTask;
+ import android.os.Handler;
+ import android.os.RemoteException;
+@@ -74,6 +77,7 @@ public class UserSwitcherController {
+     private ArrayList<UserRecord> mUsers = new ArrayList<>();
+     private Dialog mExitGuestDialog;
+     private Dialog mAddUserDialog;
++    private Dialog mEncryptUserDialog;
+     private int mLastNonGuestUser = UserHandle.USER_OWNER;
+     private boolean mSimpleUserSwitcher;
+     private boolean mAddUsersWhenLocked;
+@@ -253,8 +257,16 @@ public class UserSwitcherController {
+     }
+ 
+     private void switchToUserId(int id) {
++        final IBinder binder = ServiceManager.getService("efsservice");
++        final int currentUser = ActivityManager.getCurrentUser();
++        IEFSService service = null;
++        if (binder != null)
++            service = IEFSService.Stub.asInterface(binder);
+         try {
+             ActivityManagerNative.getDefault().switchUser(id);
++            if (service != null)
++                if (mUserManager.getUserInfo(currentUser).isEncrypted())
++                    service.lockUserData(currentUser);
+         } catch (RemoteException e) {
+             Log.e(TAG, "Couldn't switch user.", e);
+         }
+@@ -276,6 +288,14 @@ public class UserSwitcherController {
+         mAddUserDialog.show();
+     }
+ 
++    private void showEncryptUserDialog() {
++        if (mEncryptUserDialog != null && mEncryptUserDialog.isShowing()) {
++            mEncryptUserDialog.cancel();
++        }
++        mEncryptUserDialog = new EncryptUserDialog(mContext);
++        mEncryptUserDialog.show();
++    }
++
+     private void exitGuest(int id) {
+         int newId = UserHandle.USER_OWNER;
+         if (mLastNonGuestUser != UserHandle.USER_OWNER) {
+@@ -574,19 +594,46 @@ public class UserSwitcherController {
+                 if (ActivityManager.isUserAMonkey()) {
+                     return;
+                 }
+-                UserInfo user = mUserManager.createSecondaryUser(
+-                        mContext.getString(R.string.user_new_user_name), 0 /* flags */);
+-                if (user == null) {
+-                    // Couldn't create user, most likely because there are too many, but we haven't
+-                    // been able to reload the list yet.
+-                    return;
+-                }
+-                int id = user.id;
+-                Bitmap icon = UserIcons.convertToBitmap(UserIcons.getDefaultUserIcon(
+-                        id, /* light= */ false));
+-                mUserManager.setUserIcon(id, icon);
+-                switchToUserId(id);
++                showEncryptUserDialog();
++            }
++        }
++    }
++
++    private final class EncryptUserDialog extends SystemUIDialog implements
++            DialogInterface.OnClickListener {
++
++        String title = "Encryption";
++        String message = "Encrypt new user?";
++
++        public EncryptUserDialog(Context context) {
++            super(context);
++            setTitle(title);
++            setMessage(message);
++            setButton(DialogInterface.BUTTON_NEGATIVE,
++                    context.getString(android.R.string.no), this);
++            setButton(DialogInterface.BUTTON_POSITIVE,
++                    context.getString(android.R.string.yes), this);
++        }
++
++        @Override
++        public void onClick(DialogInterface dialog, int which) {
++            dismiss();
++            if (ActivityManager.isUserAMonkey()) {
++                return;
++            }
++            UserInfo user = mUserManager.createSecondaryUser(
++                mContext.getString(R.string.user_new_user_name),
++                which == BUTTON_POSITIVE ? UserInfo.FLAG_ENCRYPTED : 0);
++            if (user == null) {
++                // Couldn't create user, most likely because there are too many, but we haven't
++                // been able to reload the list yet.
++                return;
+             }
++            int id = user.id;
++            Bitmap icon = UserIcons.convertToBitmap(UserIcons.getDefaultUserIcon(
++                    id, /* light= */ false));
++            mUserManager.setUserIcon(id, icon);
++            switchToUserId(id);
+         }
+     }
+ }
+diff --git a/services/core/java/com/android/server/pm/UserManagerService.java b/services/core/java/com/android/server/pm/UserManagerService.java
+index 0cf2249..8255399 100644
+--- a/services/core/java/com/android/server/pm/UserManagerService.java
++++ b/services/core/java/com/android/server/pm/UserManagerService.java
+@@ -22,6 +22,7 @@ import android.app.Activity;
+ import android.app.ActivityManager;
+ import android.app.ActivityManagerNative;
+ import android.app.IStopUserCallback;
++import android.app.admin.DevicePolicyManager;
+ import android.content.BroadcastReceiver;
+ import android.content.Context;
+ import android.content.Intent;
+@@ -37,12 +38,14 @@ import android.os.Debug;
+ import android.os.Environment;
+ import android.os.FileUtils;
+ import android.os.Handler;
++import android.os.IBinder;
+ import android.os.IUserManager;
+ import android.os.Process;
+ import android.os.RemoteException;
+ import android.os.ServiceManager;
+ import android.os.UserHandle;
+ import android.os.UserManager;
++import android.os.storage.IEFSService;
+ import android.util.AtomicFile;
+ import android.util.Log;
+ import android.util.Slog;
+@@ -54,6 +57,7 @@ import android.util.Xml;
+ import com.android.internal.app.IAppOpsService;
+ import com.android.internal.util.ArrayUtils;
+ import com.android.internal.util.FastXmlSerializer;
++import com.android.internal.widget.LockPatternUtils;
+ 
+ import org.xmlpull.v1.XmlPullParser;
+ import org.xmlpull.v1.XmlPullParserException;
+@@ -855,7 +859,7 @@ public class UserManagerService extends IUserManager.Stub {
+         }
+     }
+ 
+-    private void writeRestrictionsLocked(XmlSerializer serializer, Bundle restrictions) 
++    private void writeRestrictionsLocked(XmlSerializer serializer, Bundle restrictions)
+             throws IOException {
+         serializer.startTag(null, TAG_RESTRICTIONS);
+         writeBoolean(serializer, restrictions, UserManager.DISALLOW_CONFIG_WIFI);
+@@ -1189,9 +1193,33 @@ public class UserManagerService extends IUserManager.Stub {
+                     userInfo.partial = false;
+                     writeUserLocked(userInfo);
+                     updateUserIdsLocked();
++                    if (userInfo.isEncrypted()) {
++                        int res;
++                        final String defaultPassword = "0000";
++                        final IBinder efsbinder = ServiceManager.getService("efsservice");
++                        if (efsbinder != null) {
++                            final IEFSService efsservice = IEFSService.Stub.asInterface(efsbinder);
++                            final LockPatternUtils lpu = new LockPatternUtils(mContext);
++                            try {
++                                lpu.saveLockPassword(defaultPassword,
++                                                     DevicePolicyManager.PASSWORD_QUALITY_NUMERIC,
++                                                     false, userId);
++                                res = efsservice.createEfsStorage(userPath.toString(), defaultPassword);
++                                if (res == 0) {
++                                    /*
++                                     * TODO - Encrypt media directory... somehow
++                                     * */
++                                } else {
++                                    Log.e(LOG_TAG, "Failed to create secure storage");
++                                }
++                            } catch (Exception e) {
++                                Log.e(LOG_TAG, "Error creating secure storage", e);
++                            }
++                        }
++                    }
+                     Bundle restrictions = new Bundle();
+                     mUserRestrictions.append(userId, restrictions);
+-                }
++               }
+             }
+             if (userInfo != null) {
+                 Intent addedIntent = new Intent(Intent.ACTION_USER_ADDED);
+diff --git a/services/core/java/com/android/server/power/Notifier.java b/services/core/java/com/android/server/power/Notifier.java
+index 94a628d..cec94c0 100644
+--- a/services/core/java/com/android/server/power/Notifier.java
++++ b/services/core/java/com/android/server/power/Notifier.java
+@@ -24,6 +24,7 @@ import com.android.internal.app.IBatteryStats;
+ import com.android.server.EventLogTags;
+ import com.android.server.LocalServices;
+ 
++import android.app.ActivityManager;
+ import android.app.ActivityManagerNative;
+ import android.content.BroadcastReceiver;
+ import android.content.Context;
+@@ -35,14 +36,18 @@ import android.media.RingtoneManager;
+ import android.net.Uri;
+ import android.os.BatteryStats;
+ import android.os.Handler;
++import android.os.IBinder;
+ import android.os.Looper;
+ import android.os.Message;
+ import android.os.PowerManager;
+ import android.os.Process;
+ import android.os.RemoteException;
++import android.os.ServiceManager;
+ import android.os.SystemClock;
+ import android.os.UserHandle;
++import android.os.UserManager;
+ import android.os.WorkSource;
++import android.os.storage.IEFSService;
+ import android.provider.Settings;
+ import android.util.EventLog;
+ import android.util.Slog;
+@@ -87,6 +92,7 @@ final class Notifier {
+     private final WindowManagerPolicy mPolicy;
+     private final ActivityManagerInternal mActivityManagerInternal;
+     private final InputManagerInternal mInputManagerInternal;
++    private final UserManager mUserManager;
+ 
+     private final NotifierHandler mHandler;
+     private final Intent mScreenOnIntent;
+@@ -119,6 +125,7 @@ final class Notifier {
+         mPolicy = policy;
+         mActivityManagerInternal = LocalServices.getService(ActivityManagerInternal.class);
+         mInputManagerInternal = LocalServices.getService(InputManagerInternal.class);
++		 mUserManager = UserManager.get(context);
+ 
+         mHandler = new NotifierHandler(looper);
+         mScreenOnIntent = new Intent(Intent.ACTION_SCREEN_ON);
+@@ -320,6 +327,15 @@ final class Notifier {
+         }
+ 
+         if (!interactive) {
++            final IBinder binder = ServiceManager.getService("efsservice");
++            final int currentUser = ActivityManager.getCurrentUser();
++            if (binder != null) {
++                final IEFSService service = IEFSService.Stub.asInterface(binder);
++                try {
++                    if (service != null && mUserManager.getUserInfo(currentUser).isEncrypted())
++                        service.lockUserData(currentUser);
++                } catch (RemoteException ex) {}
++            }
+             try {
+                 mBatteryStats.noteInteractive(false);
+             } catch (RemoteException ex) { }
 diff --git a/services/java/com/android/server/SystemServer.java b/services/java/com/android/server/SystemServer.java
 index 22f6ca4..8564364 100644
 --- a/services/java/com/android/server/SystemServer.java

--- a/integration/user/android-5.0.2_r1/settings/settings.patch
+++ b/integration/user/android-5.0.2_r1/settings/settings.patch
@@ -1,0 +1,218 @@
+From 32a45946639b58d365bea649b65910b6311d0428 Mon Sep 17 00:00:00 2001
+From: Nicolae-Alexandru Ivan <alexandru.ivan@intel.com>
+Date: Wed, 29 Apr 2015 16:16:36 +0300
+Subject: [PATCH] Integrate multi-user encryption into Settings app
+
+There is currently a security issue when changing the password for a
+storage. Since we need the old password, which is checked in a different
+activity than the one where the new password is introduced, we have to
+pass it between activities.
+---
+ res/values/strings.xml                            |  3 ++
+ src/com/android/settings/ChooseLockPassword.java  | 16 ++++++++
+ src/com/android/settings/ConfirmLockPassword.java |  3 ++
+ src/com/android/settings/users/UserSettings.java  | 48 +++++++++++++++++++----
+ 4 files changed, 63 insertions(+), 7 deletions(-)
+
+diff --git a/res/values/strings.xml b/res/values/strings.xml
+index 0a139d5..c7237c1 100644
+--- a/res/values/strings.xml
++++ b/res/values/strings.xml
+@@ -5231,6 +5231,9 @@
+     <!-- Message to limited users that they cannot add accounts [CHAR LIMIT=100] -->
+     <string name="user_cannot_add_accounts_message">Restricted profiles cannot add accounts</string>
+ 
++    <string name="user_encrypted_title">Encryption</string>
++    <string name="user_encrypted_message">Encrypt new user?</string>
++
+     <!-- User details remove user menu [CHAR LIMIT=20] -->
+     <string name="user_remove_user_menu">Delete <xliff:g id="user_name">%1$s</xliff:g> from this device</string>
+     <!-- User menu to allow creating new users from lockscreen [CHAR LIMIT=30] -->
+diff --git a/src/com/android/settings/ChooseLockPassword.java b/src/com/android/settings/ChooseLockPassword.java
+index b72d5c5..e07e367 100644
+--- a/src/com/android/settings/ChooseLockPassword.java
++++ b/src/com/android/settings/ChooseLockPassword.java
+@@ -30,7 +30,11 @@ import android.content.Intent;
+ import android.inputmethodservice.KeyboardView;
+ import android.os.Bundle;
+ import android.os.Handler;
++import android.os.IBinder;
+ import android.os.Message;
++import android.os.ServiceManager;
++import android.os.UserManager;
++import android.os.storage.IEFSService;
+ import android.provider.Settings;
+ import android.text.Editable;
+ import android.text.InputType;
+@@ -428,6 +432,18 @@ public class ChooseLockPassword extends SettingsActivity {
+                     mLockPatternUtils.clearLock(isFallback);
+                     final boolean required = getActivity().getIntent().getBooleanExtra(
+                             EncryptionInterstitial.EXTRA_REQUIRE_PASSWORD, true);
++                    final String oldpin = System.getProperty("efs.unsafe.temp");
++                    System.clearProperty("efs.unsafe.temp");
++                    final IBinder binder = ServiceManager.getService("efsservice");
++                    final UserManager um = UserManager.get(getActivity());
++                    final int currentUser = mLockPatternUtils.getCurrentUser();
++                    if (binder != null) {
++                        final IEFSService service = IEFSService.Stub.asInterface(binder);
++                        try {
++                            if (service != null && um.getUserInfo(currentUser).isEncrypted())
++                                service.changeUserDataPassword(currentUser, oldpin, pin);
++                        } catch (Exception e) {}
++                    }
+                     mLockPatternUtils.setCredentialRequiredToDecrypt(required);
+                     mLockPatternUtils.saveLockPassword(pin, mRequestedQuality, isFallback);
+                     getActivity().setResult(RESULT_FINISHED);
+diff --git a/src/com/android/settings/ConfirmLockPassword.java b/src/com/android/settings/ConfirmLockPassword.java
+index c74e861..0004945 100644
+--- a/src/com/android/settings/ConfirmLockPassword.java
++++ b/src/com/android/settings/ConfirmLockPassword.java
+@@ -194,6 +194,9 @@ public class ConfirmLockPassword extends SettingsActivity {
+             final String pin = mPasswordEntry.getText().toString();
+             if (mLockPatternUtils.checkPassword(pin)) {
+ 
++                /* Bad, evil, ugly, unsafe hack */
++                System.setProperty("efs.unsafe.temp", pin);
++
+                 Intent intent = new Intent();
+                 if (getActivity() instanceof ConfirmLockPassword.InternalActivity) {
+                     intent.putExtra(ChooseLockSettingsHelper.EXTRA_KEY_TYPE,
+diff --git a/src/com/android/settings/users/UserSettings.java b/src/com/android/settings/users/UserSettings.java
+index b95c397..f9cf648 100644
+--- a/src/com/android/settings/users/UserSettings.java
++++ b/src/com/android/settings/users/UserSettings.java
+@@ -19,6 +19,7 @@ package com.android.settings.users;
+ import android.accounts.Account;
+ import android.accounts.AccountManager;
+ import android.app.Activity;
++import android.app.ActivityManager;
+ import android.app.ActivityManagerNative;
+ import android.app.AlertDialog;
+ import android.app.Dialog;
+@@ -37,10 +38,13 @@ import android.graphics.drawable.Drawable;
+ import android.os.AsyncTask;
+ import android.os.Bundle;
+ import android.os.Handler;
++import android.os.IBinder;
+ import android.os.Message;
+ import android.os.RemoteException;
++import android.os.ServiceManager;
+ import android.os.UserHandle;
+ import android.os.UserManager;
++import android.os.storage.IEFSService;
+ import android.preference.Preference;
+ import android.preference.Preference.OnPreferenceClickListener;
+ import android.preference.PreferenceGroup;
+@@ -106,6 +110,7 @@ public class UserSettings extends SettingsPreferenceFragment
+     private static final int DIALOG_NEED_LOCKSCREEN = 7;
+     private static final int DIALOG_CONFIRM_EXIT_GUEST = 8;
+     private static final int DIALOG_USER_PROFILE_EDITOR = 9;
++    private static final int DIALOG_CHOOSE_USER_ENCRYPTED = 10;
+ 
+     private static final int MESSAGE_UPDATE_LIST = 1;
+     private static final int MESSAGE_SETUP_USER = 2;
+@@ -361,7 +366,7 @@ public class UserSettings extends SettingsPreferenceFragment
+ 
+         if (requestCode == REQUEST_CHOOSE_LOCK) {
+             if (resultCode != Activity.RESULT_CANCELED && hasLockscreenSecurity()) {
+-                addUserNow(USER_TYPE_RESTRICTED_PROFILE);
++                addUserNow(USER_TYPE_RESTRICTED_PROFILE, false);
+             }
+         } else {
+             mEditUserInfoController.onActivityResult(requestCode, resultCode, data);
+@@ -377,7 +382,7 @@ public class UserSettings extends SettingsPreferenceFragment
+                     break;
+                 case USER_TYPE_RESTRICTED_PROFILE:
+                     if (hasLockscreenSecurity()) {
+-                        addUserNow(USER_TYPE_RESTRICTED_PROFILE);
++                        addUserNow(USER_TYPE_RESTRICTED_PROFILE, false);
+                     } else {
+                         showDialog(DIALOG_NEED_LOCKSCREEN);
+                     }
+@@ -420,9 +425,10 @@ public class UserSettings extends SettingsPreferenceFragment
+         return newUserInfo;
+     }
+ 
+-    private UserInfo createTrustedUser() {
++    private UserInfo createTrustedUser(boolean isEncrypted) {
+         UserInfo newUserInfo = mUserManager.createSecondaryUser(
+-                getResources().getString(R.string.user_new_user_name), 0);
++                getResources().getString(R.string.user_new_user_name),
++                            isEncrypted ? UserInfo.FLAG_ENCRYPTED : 0);
+         if (newUserInfo != null) {
+             assignDefaultPhoto(newUserInfo);
+         }
+@@ -525,7 +531,7 @@ public class UserSettings extends SettingsPreferenceFragment
+                     .setPositiveButton(android.R.string.ok,
+                         new DialogInterface.OnClickListener() {
+                             public void onClick(DialogInterface dialog, int which) {
+-                                addUserNow(userType);
++                                showDialog(DIALOG_CHOOSE_USER_ENCRYPTED);
+                                 if (!longMessageDisplayed) {
+                                     preferences.edit().putBoolean(
+                                             KEY_ADD_USER_LONG_MESSAGE_DISPLAYED, true).apply();
+@@ -588,6 +594,27 @@ public class UserSettings extends SettingsPreferenceFragment
+                         .create();
+                 return dlg;
+             }
++            case DIALOG_CHOOSE_USER_ENCRYPTED: {
++                Dialog dlg = new AlertDialog.Builder(context)
++                        .setTitle(R.string.user_encrypted_title)
++                        .setMessage(R.string.user_encrypted_message)
++                        .setPositiveButton(android.R.string.yes,
++                                new DialogInterface.OnClickListener() {
++                                    @Override
++                                    public void onClick(DialogInterface dialog, int which) {
++                                        addUserNow(USER_TYPE_USER, true);
++                                    }
++                                })
++                        .setNegativeButton(android.R.string.no,
++                                new DialogInterface.OnClickListener() {
++                                    @Override
++                                    public void onClick(DialogInterface dialog, int which) {
++                                        addUserNow(USER_TYPE_USER, false);
++                                    }
++                                })
++                        .create();
++                return dlg;
++            }
+             case DIALOG_NEED_LOCKSCREEN: {
+                 Dialog dlg = new AlertDialog.Builder(context)
+                         .setMessage(R.string.user_need_lock_message)
+@@ -657,7 +684,7 @@ public class UserSettings extends SettingsPreferenceFragment
+         }
+     }
+ 
+-    private void addUserNow(final int userType) {
++    private void addUserNow(final int userType, final boolean isEncrypted) {
+         synchronized (mUserLock) {
+             mAddingUser = true;
+             //updateUserList();
+@@ -666,7 +693,7 @@ public class UserSettings extends SettingsPreferenceFragment
+                     UserInfo user = null;
+                     // Could take a few seconds
+                     if (userType == USER_TYPE_USER) {
+-                        user = createTrustedUser();
++                        user = createTrustedUser(isEncrypted);
+                     } else {
+                         user = createLimitedUser();
+                     }
+@@ -687,8 +714,15 @@ public class UserSettings extends SettingsPreferenceFragment
+     }
+ 
+     private void switchUserNow(int userId) {
++        final IBinder binder = ServiceManager.getService("efsservice");
++        final int currentUser = ActivityManager.getCurrentUser();
++        IEFSService service = null;
++        if (binder != null)
++            service = IEFSService.Stub.asInterface(binder);
+         try {
+             ActivityManagerNative.getDefault().switchUser(userId);
++            if (service != null && mUserManager.getUserInfo(currentUser).isEncrypted())
++                service.lockUserData(currentUser);
+         } catch (RemoteException re) {
+             // Nothing to do
+         }
+-- 
+1.9.1
+


### PR DESCRIPTION
Known issues:
When locking/unlocking the user there may be processes that
have open file descriptors inside the storage. Currently, we just kill
these and it sometimes results in error dialogs that are not cleared and
get to the user. Functionally, the process has already been restarted by
the time the user sees the message.

There is currently a security issue when changing the password for a
storage. Since we need the old password, which is checked in a different
activity than the one where the new password is introduced, we have to
pass it between activities.